### PR TITLE
Fix predicate pushdown for string columns

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -81,7 +81,7 @@ jobs:
         aarch64_cross_compile: 1
 
     - name: Setup vcpkg
-      uses: lukka/run-vcpkg@v11
+      uses: lukka/run-vcpkg@v11.1
       with:
         vcpkgGitCommitId: 8eb57355a4ffb410a2e94c07b4dca2dffbee8e50
 

--- a/src/mysql_filter_pushdown.cpp
+++ b/src/mysql_filter_pushdown.cpp
@@ -46,7 +46,7 @@ string MySQLFilterPushdown::TransformFilter(string &column_name, TableFilter &fi
 	}
 	case TableFilterType::CONSTANT_COMPARISON: {
 		auto &constant_filter = filter.Cast<ConstantFilter>();
-		auto constant_string = constant_filter.constant.ToString();
+		auto constant_string = constant_filter.constant.ToSQLString();
 		auto operator_string = TransformComparision(constant_filter.comparison_type);
 		return StringUtil::Format("%s %s %s", column_name, operator_string, constant_string);
 	}

--- a/test/sql/attach_filter_pushdown.test
+++ b/test/sql/attach_filter_pushdown.test
@@ -5,6 +5,9 @@
 require mysql_scanner
 
 statement ok
+SET GLOBAL mysql_experimental_filter_pushdown=true;
+
+statement ok
 ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
 
 statement ok
@@ -15,5 +18,16 @@ INSERT INTO s1.filter_pushdown FROM range(100000)
 
 query I
 SELECT * FROM s1.filter_pushdown WHERE i=52525
+----
+52525
+
+statement ok
+CREATE OR REPLACE TABLE s1.filter_pushdown_string(i STRING)
+
+statement ok
+INSERT INTO s1.filter_pushdown_string SELECT CAST(range AS STRING) FROM range(100000);
+
+query I
+SELECT * FROM s1.filter_pushdown_string WHERE i='52525'
 ----
 52525


### PR DESCRIPTION
Using [ToSQLString](https://github.com/duckdb/duckdb/blob/3a9c632008f105775d01ac41aedc49604e1c6ba9/src/common/types/value.cpp#L1316) should fix pushdown predicates constant value output to the underlying mysql.

Before:
`SELECT * FROM filter_pushdown_string WHERE my_string_field=somevalue`

After:
`SELECT * FROM filter_pushdown_string WHERE my_string_field='somevalue'`