### PR TITLE
Add `mysql_max_threads` extension option

### DIFF
--- a/src/mysql_extension.cpp
+++ b/src/mysql_extension.cpp
@@ -31,6 +31,10 @@ static void LoadInternal(DatabaseInstance &db) {
 	                          Value::BOOLEAN(false));
 	config.AddExtensionOption("mysql_debug_show_queries", "DEBUG SETTING: print all queries sent to MySQL to stdout",
 	                          LogicalType::BOOLEAN, Value::BOOLEAN(false), SetMySQLDebugQueryPrint);
+	
+	config.AddExtensionOption("mysql_max_threads",
+													  "Maximum number of threads to use for MySQL queries",
+	                          LogicalType::SMALLINT, Value::SMALLINT(1));
 }
 
 void MySQLScannerExtension::Load(DuckDB &db) {


### PR DESCRIPTION
To support multi threading, in the extension, it's hard to find a "magic number" so letting the user pick the number felt like a first step in the right direction.

@Mytherin, this isn't fixing parallelism across multiple attached DBs so I'm digging into [parallelSource](https://github.com/duckdb/duckdb/blob/a00b28f5d453ff7ec3b3837385f083d0887124ad/src/include/duckdb/execution/physical_operator.hpp#L116-L118) but I'm not sure yet it's the blocker.