### PR TITLE
WIP complex filter pushdown

### DIFF
--- a/src/include/mysql_filter_pushdown.hpp
+++ b/src/include/mysql_filter_pushdown.hpp
@@ -11,6 +11,7 @@
 #include "duckdb/planner/table_filter.hpp"
 #include "duckdb/planner/filter/conjunction_filter.hpp"
 #include "duckdb/planner/filter/constant_filter.hpp"
+#include "duckdb/function/table_function.hpp"
 
 namespace duckdb {
 
@@ -18,6 +19,8 @@ class MySQLFilterPushdown {
 public:
 	static string TransformFilters(const vector<column_t> &column_ids, optional_ptr<TableFilterSet> filters,
 	                               const vector<string> &names);
+	static void ComplexFilterPushdown(ClientContext &context, LogicalGet &get, FunctionData *bind_data_p,
+                                     vector<unique_ptr<Expression>> &filters);
 
 private:
 	static string TransformFilter(string &column_name, TableFilter &filter);

--- a/src/include/mysql_scanner.hpp
+++ b/src/include/mysql_scanner.hpp
@@ -24,6 +24,8 @@ struct MySQLBindData : public FunctionData {
 	vector<MySQLType> mysql_types;
 	vector<string> names;
 	vector<LogicalType> types;
+	//Filter pushdown to apply
+	vector<unique_ptr<Expression>> filters_to_apply;
 
 public:
 	unique_ptr<FunctionData> Copy() const override {

--- a/src/include/storage/mysql_table_entry.hpp
+++ b/src/include/storage/mysql_table_entry.hpp
@@ -10,6 +10,7 @@
 
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
+#include "mysql_filter_pushdown.hpp"
 #include "mysql_utils.hpp"
 
 namespace duckdb {

--- a/src/mysql_scanner.cpp
+++ b/src/mysql_scanner.cpp
@@ -79,6 +79,7 @@ static unique_ptr<LocalTableFunctionState> MySQLInitLocalState(ExecutionContext 
 
 static void MySQLScan(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
 	auto &gstate = data.global_state->Cast<MySQLGlobalState>();
+	data.bind_data->Cast<MySQLBindData>();
 	idx_t r;
 	for (r = 0; r < STANDARD_VECTOR_SIZE; r++) {
 		if (!gstate.result->Next()) {

--- a/src/storage/mysql_table_entry.cpp
+++ b/src/storage/mysql_table_entry.cpp
@@ -35,6 +35,7 @@ TableFunction MySQLTableEntry::GetScanFunction(ClientContext &context, unique_pt
 	Value filter_pushdown;
 	if (context.TryGetCurrentSetting("mysql_experimental_filter_pushdown", filter_pushdown)) {
 		function.filter_pushdown = BooleanValue::Get(filter_pushdown);
+		function.pushdown_complex_filter = MySQLFilterPushdown::ComplexFilterPushdown;
 	}
 	return function;
 }


### PR DESCRIPTION
This is a work in progress that aims to support more filters.
My first goal is to support the `IN` but I'll likely need to support more I'm not sure exactly what the `ExpressionClass` I'm supporting exactly contains.

@Mytherin, few questions to move forward:
- Is adding a `vector<unique_ptr<Expression>>` in `MySQLBindData` instead of `input.filters` from `TableFunctionInitInput &input` the right approach?  Won't I run in a side effect or anything else?
- Should I figure out how to move from a `vector<unique_ptr<Expression>>` to a `vector<unique_ptr<TableFilter>> &filters` or should I update all the filter pushdown logic to support `vector<unique_ptr<Expression>>` instead?

Thanks!