### PR TITLE
Fix #16 - avoid including time zone information when inserting timestamps with time zones as MySQL does not support this, instead ship the raw UTC values

### DIFF
--- a/src/storage/mysql_insert.cpp
+++ b/src/storage/mysql_insert.cpp
@@ -152,6 +152,12 @@ SinkResultType MySQLInsert::Sink(ExecutionContext &context, DataChunk &chunk, Op
 		case LogicalTypeId::BLOB:
 			MySQLCastBlob(chunk.data[c], gstate.varchar_chunk.data[c], chunk.size());
 			break;
+		case LogicalTypeId::TIMESTAMP_TZ: {
+			Vector timestamp_vector(LogicalType::TIMESTAMP);
+			timestamp_vector.Reinterpret(chunk.data[c]);
+			VectorOperations::Cast(context.client, timestamp_vector, gstate.varchar_chunk.data[c], chunk.size());
+			break;
+		}
 		default:
 			VectorOperations::Cast(context.client, chunk.data[c], gstate.varchar_chunk.data[c], chunk.size());
 			break;

--- a/test/sql/attach_timestamp_issue_16.test
+++ b/test/sql/attach_timestamp_issue_16.test
@@ -1,0 +1,21 @@
+# name: test/sql/attach_timestamp_issue_16.test
+# description: Test creating a table with TIMESTAMP_TZ values
+# group: [sql]
+
+require mysql_scanner
+
+statement ok
+ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s (TYPE MYSQL_SCANNER)
+
+statement ok
+USE s
+
+statement ok
+DROP TABLE IF EXISTS datetime_tbl_2
+
+statement ok
+CREATE TABLE datetime_tbl_2 AS SELECT * FROM datetime_tbl
+
+query IIIII
+SELECT * FROM datetime_tbl_2 EXCEPT SELECT * FROM datetime_tbl
+----

--- a/test/sql/attach_timezone_insert.test
+++ b/test/sql/attach_timezone_insert.test
@@ -1,0 +1,22 @@
+# name: test/sql/attach_timezone_insert.test
+# description: Test inserting timestamp with time zones into MySQL
+# group: [sql]
+
+require mysql_scanner
+
+statement ok
+ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s (TYPE MYSQL_SCANNER)
+
+statement ok
+USE s
+
+statement ok
+CREATE OR REPLACE TABLE timestamp_with_tz_tbl(ts TIMESTAMP WITH TIME ZONE);
+
+statement ok
+INSERT INTO timestamp_with_tz_tbl VALUES (TIMESTAMP '2000-01-01 12:12:12')
+
+query I
+SELECT * FROM timestamp_with_tz_tbl
+----
+2000-01-01 12:12:12+00


### PR DESCRIPTION
Fixes #16