### PR TITLE
Fix #25: interpret TINYINT(1) and BIT(1) as booleans by default, and add settings to disable this behavior

### DIFF
--- a/src/include/mysql_result.hpp
+++ b/src/include/mysql_result.hpp
@@ -29,6 +29,10 @@ public:
 		D_ASSERT(res);
 		return string(GetNonNullValue(col), lengths[col]);
 	}
+	string_t GetStringT(idx_t col) {
+		D_ASSERT(res);
+		return string_t(GetNonNullValue(col), lengths[col]);
+	}
 	int32_t GetInt32(idx_t col) {
 		return atoi(GetNonNullValue(col));
 	}

--- a/src/include/mysql_scanner.hpp
+++ b/src/include/mysql_scanner.hpp
@@ -42,6 +42,8 @@ public:
 class MySQLClearCacheFunction : public TableFunction {
 public:
 	MySQLClearCacheFunction();
+
+	static void ClearCacheOnSetting(ClientContext &context, SetScope scope, Value &parameter);
 };
 
 } // namespace duckdb

--- a/src/include/mysql_utils.hpp
+++ b/src/include/mysql_utils.hpp
@@ -46,7 +46,7 @@ public:
 	static MYSQL *Connect(const string &dsn);
 
 	static LogicalType ToMySQLType(const LogicalType &input);
-	static LogicalType TypeToLogicalType(const MySQLTypeData &input);
+	static LogicalType TypeToLogicalType(ClientContext &context, const MySQLTypeData &input);
 	static string TypeToString(const LogicalType &input);
 
 	static string WriteIdentifier(const string &identifier);

--- a/src/include/storage/mysql_table_set.hpp
+++ b/src/include/storage/mysql_table_set.hpp
@@ -24,9 +24,7 @@ public:
 public:
 	optional_ptr<CatalogEntry> CreateTable(ClientContext &context, BoundCreateTableInfo &info);
 
-	static unique_ptr<MySQLTableInfo> GetTableInfo(MySQLTransaction &transaction, MySQLSchemaEntry &schema,
-	                                               const string &table_name);
-	static unique_ptr<MySQLTableInfo> GetTableInfo(MySQLConnection &connection, const string &schema_name,
+	static unique_ptr<MySQLTableInfo> GetTableInfo(ClientContext &context, MySQLSchemaEntry &schema,
 	                                               const string &table_name);
 	optional_ptr<CatalogEntry> RefreshTable(ClientContext &context, const string &table_name);
 
@@ -40,7 +38,7 @@ protected:
 	void AlterTable(ClientContext &context, AddColumnInfo &info);
 	void AlterTable(ClientContext &context, RemoveColumnInfo &info);
 
-	static void AddColumn(MySQLResult &result, MySQLTableInfo &table_info, idx_t column_offset = 0);
+	static void AddColumn(ClientContext &context, MySQLResult &result, MySQLTableInfo &table_info, idx_t column_offset = 0);
 
 protected:
 	MySQLSchemaEntry &schema;

--- a/src/mysql_extension.cpp
+++ b/src/mysql_extension.cpp
@@ -31,6 +31,12 @@ static void LoadInternal(DatabaseInstance &db) {
 	                          Value::BOOLEAN(false));
 	config.AddExtensionOption("mysql_debug_show_queries", "DEBUG SETTING: print all queries sent to MySQL to stdout",
 	                          LogicalType::BOOLEAN, Value::BOOLEAN(false), SetMySQLDebugQueryPrint);
+	config.AddExtensionOption("mysql_tinyint1_as_boolean",
+							  "Whether or not to convert TINYINT(1) columns to BOOLEAN", LogicalType::BOOLEAN,
+							  Value::BOOLEAN(true), MySQLClearCacheFunction::ClearCacheOnSetting);
+	config.AddExtensionOption("mysql_bit1_as_boolean",
+							  "Whether or not to convert BIT(1) columns to BOOLEAN", LogicalType::BOOLEAN,
+							  Value::BOOLEAN(true), MySQLClearCacheFunction::ClearCacheOnSetting);
 }
 
 void MySQLScannerExtension::Load(DuckDB &db) {

--- a/test/sql/attach_clear_cache.test
+++ b/test/sql/attach_clear_cache.test
@@ -1,0 +1,67 @@
+# name: test/sql/attach_clear_cache.test
+# description: Vigorously clear caches
+# group: [sql]
+
+require mysql_scanner
+
+require-env MYSQL_TEST_DATABASE_AVAILABLE
+
+statement ok
+ATTACH 'host=localhost user=root port=0 database=mysql' AS simple (TYPE MYSQL_SCANNER)
+
+statement ok
+DROP TABLE IF EXISTS simple.test
+
+statement ok
+CALL mysql_clear_cache();
+
+statement ok
+CREATE TABLE simple.test(i INTEGER);
+
+statement ok
+CALL mysql_clear_cache();
+
+query I
+INSERT INTO simple.test VALUES (42);
+----
+1
+
+statement ok
+CALL mysql_clear_cache();
+
+query I
+SELECT * FROM simple.test
+----
+42
+
+statement ok
+CALL mysql_clear_cache();
+
+# insert into a non-existent table
+statement error
+INSERT INTO simple.tst VALUES (84)
+----
+test
+
+statement ok
+CALL mysql_clear_cache();
+
+statement error
+INSERT INTO simple.tst VALUES (84)
+----
+test
+
+statement ok
+CALL mysql_clear_cache();
+
+# create table as
+statement ok
+CREATE OR REPLACE TABLE simple.test2 AS SELECT 84
+
+statement ok
+CALL mysql_clear_cache();
+
+query I
+SELECT * FROM simple.test2
+----
+84

--- a/test/sql/attach_fake_booleans.test
+++ b/test/sql/attach_fake_booleans.test
@@ -1,0 +1,52 @@
+# name: test/sql/attach_fake_booleans.test
+# description: Test fake booleans
+# group: [sql]
+
+require mysql_scanner
+
+require-env MYSQL_TEST_DATABASE_AVAILABLE
+
+statement ok
+SET GLOBAL mysql_experimental_filter_pushdown=true;
+
+statement ok
+ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+
+query II
+SELECT * FROM s1.fake_booleans
+----
+true	true
+false	false
+NULL	NULL
+
+query II
+SELECT typeof(tinyint_bool), typeof(bit_bool) FROM s1.fake_booleans LIMIT 1
+----
+BOOLEAN	BOOLEAN
+
+statement ok
+SET mysql_tinyint1_as_boolean=false
+
+query II
+SELECT typeof(tinyint_bool), typeof(bit_bool) FROM s1.fake_booleans LIMIT 1
+----
+TINYINT	BOOLEAN
+
+statement ok
+SET mysql_bit1_as_boolean=false
+
+query II
+SELECT typeof(tinyint_bool), typeof(bit_bool) FROM s1.fake_booleans LIMIT 1
+----
+TINYINT	BLOB
+
+statement ok
+SET mysql_tinyint1_as_boolean=true
+
+statement ok
+SET mysql_bit1_as_boolean=true
+
+query II
+SELECT typeof(tinyint_bool), typeof(bit_bool) FROM s1.fake_booleans LIMIT 1
+----
+BOOLEAN	BOOLEAN

--- a/test/test_data.sql
+++ b/test/test_data.sql
@@ -80,6 +80,9 @@ INSERT INTO decimals VALUES (
 	NULL
 );
 
+-- MySQL doesn't support a "proper" boolean so people often use TINYINT(1) or BIT(1) as boolean
+CREATE TABLE fake_booleans(tinyint_bool TINYINT(1), bit_bool BIT(1));
+INSERT INTO fake_booleans VALUES (true, true), (false, false), (NULL, NULL);
 
 CREATE TABLE bits(b BIT(6), bl BIT(64));
 INSERT INTO bits VALUES (b'000101', b'010101010101010101');


### PR DESCRIPTION
Fixes #25

Apparently MySQL lacks a proper boolean type and `TINYINT(1)` and `BIT(1)` are commonly used instead. To support this behavior we now convert these types to boolean by default. We also add two new settings to disable this behavior: `mysql_tinyint1_as_boolean` and `mysql_bit1_as_boolean`.