### PR TITLE
Correctly label internal tables for COPY FROM DATABASE/EXPORT

### DIFF
--- a/src/include/storage/mysql_catalog_set.hpp
+++ b/src/include/storage/mysql_catalog_set.hpp
@@ -14,6 +14,7 @@
 
 namespace duckdb {
 struct DropInfo;
+class MySQLSchemaEntry;
 class MySQLTransaction;
 
 class MySQLCatalogSet {
@@ -23,7 +24,7 @@ public:
 	optional_ptr<CatalogEntry> GetEntry(ClientContext &context, const string &name);
 	virtual void DropEntry(ClientContext &context, DropInfo &info);
 	void Scan(ClientContext &context, const std::function<void(CatalogEntry &)> &callback);
-	optional_ptr<CatalogEntry> CreateEntry(unique_ptr<CatalogEntry> entry);
+	virtual optional_ptr<CatalogEntry> CreateEntry(unique_ptr<CatalogEntry> entry);
 	void ClearEntries();
 
 protected:
@@ -38,6 +39,16 @@ private:
 	mutex entry_lock;
 	case_insensitive_map_t<unique_ptr<CatalogEntry>> entries;
 	bool is_loaded;
+};
+
+class MySQLInSchemaSet : public MySQLCatalogSet {
+public:
+	MySQLInSchemaSet(MySQLSchemaEntry &schema);
+
+	optional_ptr<CatalogEntry> CreateEntry(unique_ptr<CatalogEntry> entry) override;
+
+protected:
+	MySQLSchemaEntry &schema;
 };
 
 } // namespace duckdb

--- a/src/include/storage/mysql_index_set.hpp
+++ b/src/include/storage/mysql_index_set.hpp
@@ -14,7 +14,7 @@
 namespace duckdb {
 class MySQLSchemaEntry;
 
-class MySQLIndexSet : public MySQLCatalogSet {
+class MySQLIndexSet : public MySQLInSchemaSet {
 public:
 	MySQLIndexSet(MySQLSchemaEntry &schema);
 
@@ -22,9 +22,6 @@ public:
 
 protected:
 	void LoadEntries(ClientContext &context) override;
-
-protected:
-	MySQLSchemaEntry &schema;
 };
 
 } // namespace duckdb

--- a/src/include/storage/mysql_table_set.hpp
+++ b/src/include/storage/mysql_table_set.hpp
@@ -17,7 +17,7 @@ class MySQLConnection;
 class MySQLResult;
 class MySQLSchemaEntry;
 
-class MySQLTableSet : public MySQLCatalogSet {
+class MySQLTableSet : public MySQLInSchemaSet {
 public:
 	explicit MySQLTableSet(MySQLSchemaEntry &schema);
 
@@ -40,9 +40,6 @@ protected:
 
 	static void AddColumn(ClientContext &context, MySQLResult &result, MySQLTableInfo &table_info,
 	                      idx_t column_offset = 0);
-
-protected:
-	MySQLSchemaEntry &schema;
 };
 
 } // namespace duckdb

--- a/src/storage/mysql_catalog_set.cpp
+++ b/src/storage/mysql_catalog_set.cpp
@@ -1,6 +1,8 @@
 #include "storage/mysql_catalog_set.hpp"
 #include "storage/mysql_transaction.hpp"
 #include "duckdb/parser/parsed_data/drop_info.hpp"
+#include "storage/mysql_schema_entry.hpp"
+
 namespace duckdb {
 
 MySQLCatalogSet::MySQLCatalogSet(Catalog &catalog) : catalog(catalog), is_loaded(false) {
@@ -67,6 +69,17 @@ optional_ptr<CatalogEntry> MySQLCatalogSet::CreateEntry(unique_ptr<CatalogEntry>
 void MySQLCatalogSet::ClearEntries() {
 	entries.clear();
 	is_loaded = false;
+}
+
+MySQLInSchemaSet::MySQLInSchemaSet(MySQLSchemaEntry &schema) :
+	MySQLCatalogSet(schema.ParentCatalog()), schema(schema) {
+}
+
+optional_ptr<CatalogEntry> MySQLInSchemaSet::CreateEntry(unique_ptr<CatalogEntry> entry) {
+	if (!entry->internal) {
+		entry->internal = schema.internal;
+	}
+	return MySQLCatalogSet::CreateEntry(std::move(entry));
 }
 
 } // namespace duckdb

--- a/src/storage/mysql_index_set.cpp
+++ b/src/storage/mysql_index_set.cpp
@@ -7,7 +7,7 @@
 
 namespace duckdb {
 
-MySQLIndexSet::MySQLIndexSet(MySQLSchemaEntry &schema) : MySQLCatalogSet(schema.ParentCatalog()), schema(schema) {
+MySQLIndexSet::MySQLIndexSet(MySQLSchemaEntry &schema) : MySQLInSchemaSet(schema) {
 }
 
 void MySQLIndexSet::DropEntry(ClientContext &context, DropInfo &info) {

--- a/src/storage/mysql_schema_entry.cpp
+++ b/src/storage/mysql_schema_entry.cpp
@@ -13,8 +13,15 @@
 
 namespace duckdb {
 
+static bool MySQLSchemaIsInternal(const string &name) {
+	if (name == "information_schema" || name == "performance_schema" || name == "sys") {
+		return true;
+	}
+	return false;
+}
+
 MySQLSchemaEntry::MySQLSchemaEntry(Catalog &catalog, string name)
-    : SchemaCatalogEntry(catalog, std::move(name), true), tables(*this), indexes(*this) {
+    : SchemaCatalogEntry(catalog, name, MySQLSchemaIsInternal(name)), tables(*this), indexes(*this) {
 }
 
 MySQLTransaction &GetMySQLTransaction(CatalogTransaction transaction) {

--- a/src/storage/mysql_table_entry.cpp
+++ b/src/storage/mysql_table_entry.cpp
@@ -1,4 +1,5 @@
 #include "storage/mysql_catalog.hpp"
+#include "storage/mysql_schema_entry.hpp"
 #include "storage/mysql_table_entry.hpp"
 #include "storage/mysql_transaction.hpp"
 #include "duckdb/storage/statistics/base_statistics.hpp"
@@ -7,12 +8,79 @@
 
 namespace duckdb {
 
+static bool TableIsInternal(const SchemaCatalogEntry &schema, const string &name) {
+	if (schema.name != "mysql") {
+		return false;
+	}
+	// this is a list of all system tables
+	// https://dev.mysql.com/doc/refman/8.0/en/system-schema.html#system-schema-data-dictionary-tables
+	unordered_set<string> system_tables {
+		"audit_log_filter",
+		"audit_log_user",
+		"columns_priv",
+		"component",
+		"db",
+		"default_roles",
+		"engine_cost",
+		"event",
+		"events",
+		"firewall_group_allowlist",
+		"firewall_groups",
+		"firewall_memebership",
+		"firewall_users",
+		"firewall_whitelist",
+		"func",
+		"general_log",
+		"global_grants",
+		"gtid_executed",
+		"help_category",
+		"help_keyword",
+		"help_relation",
+		"help_topic",
+		"innodb_index_stats",
+		"innodb_table_stats",
+		"innodb_dynamic_metadata",
+		"ndb_binlog_index",
+		"password_history",
+		"parameters",
+		"plugin",
+		"procs_priv",
+		"proxies_priv",
+		"replication_asynchronous_connection_failover",
+		"replication_asynchronous_connection_failover_managed",
+		"replication_group_configuration_version",
+		"replication_group_member_actions",
+		"role_edges",
+		"routines",
+		"server_cost",
+		"servers",
+		"slave_master_info",
+		"slave_relay_log_info",
+		"slave_worker_info",
+		"slow_log",
+		"tables_priv",
+		"time_zone",
+		"time_zone_leap_second",
+		"time_zone_name",
+		"time_zone_transition",
+		"time_zone_transition_type",
+		"user"
+	};
+	auto is_internal = system_tables.find(name) != system_tables.end();
+	if (name == "tables_priv" && !is_internal) {
+		throw InternalException("eek");
+	}
+	return is_internal;
+}
+
 MySQLTableEntry::MySQLTableEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateTableInfo &info)
     : TableCatalogEntry(catalog, schema, info) {
+	this->internal = TableIsInternal(schema, name);
 }
 
 MySQLTableEntry::MySQLTableEntry(Catalog &catalog, SchemaCatalogEntry &schema, MySQLTableInfo &info)
     : TableCatalogEntry(catalog, schema, *info.create_info) {
+	this->internal = TableIsInternal(schema, name);
 }
 
 unique_ptr<BaseStatistics> MySQLTableEntry::GetStatistics(ClientContext &context, column_t column_id) {

--- a/src/storage/mysql_table_entry.cpp
+++ b/src/storage/mysql_table_entry.cpp
@@ -66,11 +66,7 @@ static bool TableIsInternal(const SchemaCatalogEntry &schema, const string &name
 		"time_zone_transition_type",
 		"user"
 	};
-	auto is_internal = system_tables.find(name) != system_tables.end();
-	if (name == "tables_priv" && !is_internal) {
-		throw InternalException("eek");
-	}
-	return is_internal;
+	return system_tables.find(name) != system_tables.end();
 }
 
 MySQLTableEntry::MySQLTableEntry(Catalog &catalog, SchemaCatalogEntry &schema, CreateTableInfo &info)

--- a/src/storage/mysql_table_set.cpp
+++ b/src/storage/mysql_table_set.cpp
@@ -13,7 +13,7 @@
 
 namespace duckdb {
 
-MySQLTableSet::MySQLTableSet(MySQLSchemaEntry &schema) : MySQLCatalogSet(schema.ParentCatalog()), schema(schema) {
+MySQLTableSet::MySQLTableSet(MySQLSchemaEntry &schema) : MySQLInSchemaSet(schema) {
 }
 
 void MySQLTableSet::AddColumn(ClientContext &context, MySQLResult &result, MySQLTableInfo &table_info,


### PR DESCRIPTION
This prevents internal system tables from being copied/exported