### PR TITLE
Fix #44 - fallback to connecting over 127.0.0.1 if localhost connection fails

### DIFF
--- a/src/mysql_utils.cpp
+++ b/src/mysql_utils.cpp
@@ -54,7 +54,10 @@ MYSQL *MySQLUtils::Connect(const string &dsn) {
 	}
 	MYSQL *result;
 	auto config = ParseConnectionParameters(dsn);
-	const char *host = config.host.size() == 0 ? nullptr : config.host.c_str();
+	if (config.host.empty() || config.host == "localhost") {
+		config.host = "127.0.0.1";
+	}
+	const char *host = config.host.c_str();
 	const char *user = config.user.size() == 0 ? nullptr : config.user.c_str();
 	const char *passwd = config.passwd.size() == 0 ? nullptr : config.passwd.c_str();
 	const char *db = config.db.size() == 0 ? nullptr : config.db.c_str();

--- a/src/mysql_utils.cpp
+++ b/src/mysql_utils.cpp
@@ -63,8 +63,7 @@ MYSQL *MySQLUtils::Connect(const string &dsn) {
 	if (!result) {
 		if (config.host.empty() || config.host == "localhost") {
 			// retry
-			config.host = "127.0.0.1";
-			result = mysql_real_connect(mysql, host, user, passwd, db, config.port, unix_socket, config.client_flag);
+			result = mysql_real_connect(mysql, "127.0.0.1", user, passwd, db, config.port, unix_socket, config.client_flag);
 			if (result) {
 				return result;
 			}


### PR DESCRIPTION
Fixes #44

When connecting to `localhost` [MySQL](https://dev.mysql.com/doc/c-api/8.0/en/mysql-real-connect.html) tries to connect over a unix socket on Unix, or shared memory on Windows. This will work in most situations - but will not work if the MySQL server is running in a VM/container.

This PR adds retry logic such that, if the connection fails and the host is not set or equal to localhost, we retry with `127.0.0.1`.