### PR TITLE
Fix #42 - allow for quotes in MySQL connect DSN

### DIFF
--- a/test/sql/attach_dsn.test
+++ b/test/sql/attach_dsn.test
@@ -1,0 +1,38 @@
+# name: test/sql/attach_dsn.test
+# description: Test attaching with complex DSNs
+# group: [sql]
+
+require mysql_scanner
+
+require-env MYSQL_TEST_DATABASE_AVAILABLE
+
+# dsn parsing failures
+statement error
+ATTACH 'host' AS s (TYPE MYSQL_SCANNER)
+----
+expected key=value pairs separated by spaces
+
+statement error
+ATTACH 'host=' AS s (TYPE MYSQL_SCANNER)
+----
+expected key=value pairs separated by spaces
+
+statement error
+ATTACH 'host="' AS s (TYPE MYSQL_SCANNER)
+----
+unterminated quote
+
+statement error
+ATTACH 'host="\' AS s (TYPE MYSQL_SCANNER)
+----
+backslash at end of dsn
+
+statement error
+ATTACH 'host="\a' AS s (TYPE MYSQL_SCANNER)
+----
+backslash can only escape
+
+statement error
+ATTACH 'host="this string contains \"quoted\" \\spaces"' AS s (TYPE MYSQL_SCANNER)
+----
+this string contains "quoted" \spaces

--- a/test/sql/attach_fake_booleans.test
+++ b/test/sql/attach_fake_booleans.test
@@ -10,7 +10,7 @@ statement ok
 SET GLOBAL mysql_experimental_filter_pushdown=true;
 
 statement ok
-ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+ATTACH '   host="localhost"  user=root   port=0   database=mysqlscanner   ' AS s1 (TYPE MYSQL_SCANNER)
 
 query II
 SELECT * FROM s1.fake_booleans

--- a/test/sql/attach_filter_pushdown.test
+++ b/test/sql/attach_filter_pushdown.test
@@ -10,7 +10,7 @@ statement ok
 SET GLOBAL mysql_experimental_filter_pushdown=true;
 
 statement ok
-ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS s1 (TYPE MYSQL_SCANNER)
+ATTACH 'host=localhost user=root port="0" database="mysqlscanner"' AS s1 (TYPE MYSQL_SCANNER)
 
 statement ok
 CREATE OR REPLACE TABLE s1.filter_pushdown(i INTEGER)


### PR DESCRIPTION
Fix #42

Allows elements in the MySQL connection string to be quoted with double quotes, e.g.:

```
ATTACH 'host="localhost" password="this is a string with spaces \"and escapes \\"' AS s (TYPE MYSQL_SCANNER)
```
