### PR TITLE
Add support for a mysql_query table function that allows you to run an arbitrary query within MySQL

### DIFF
--- a/src/include/mysql_connection.hpp
+++ b/src/include/mysql_connection.hpp
@@ -49,7 +49,7 @@ public:
 public:
 	static MySQLConnection Open(const string &connection_string);
 	void Execute(const string &query);
-	unique_ptr<MySQLResult> Query(const string &query);
+	unique_ptr<MySQLResult> Query(const string &query, optional_ptr<ClientContext> context = nullptr);
 
 	vector<IndexInfo> GetIndexInfo(const string &table_name);
 

--- a/src/include/mysql_result.hpp
+++ b/src/include/mysql_result.hpp
@@ -12,9 +12,18 @@
 
 namespace duckdb {
 
+struct MySQLField {
+	string name;
+	LogicalType type;
+};
+
 class MySQLResult {
 public:
-	MySQLResult(MYSQL_RES *res_p, idx_t field_count) : res(res_p), field_count(field_count) {
+	MySQLResult(MYSQL_RES *res_p, idx_t field_count) :
+		res(res_p), field_count(field_count) {
+	}
+	MySQLResult(MYSQL_RES *res_p, vector<MySQLField> fields_p) :
+	   res(res_p), field_count(fields_p.size()), fields(std::move(fields_p)) {
 	}
 	MySQLResult(idx_t affected_rows) : affected_rows(affected_rows) {
 	}
@@ -59,6 +68,12 @@ public:
 		}
 		return affected_rows;
 	}
+	idx_t ColumnCount() {
+		return field_count;
+	}
+	const vector<MySQLField> &Fields() {
+		return fields;
+	}
 
 private:
 	MYSQL_RES *res = nullptr;
@@ -66,6 +81,7 @@ private:
 	MYSQL_ROW mysql_row = nullptr;
 	unsigned long *lengths = nullptr;
 	idx_t field_count = 0;
+	vector<MySQLField> fields;
 
 	char *GetNonNullValue(idx_t col) {
 		auto val = GetValueInternal(col);

--- a/src/include/mysql_scanner.hpp
+++ b/src/include/mysql_scanner.hpp
@@ -40,6 +40,11 @@ public:
 	MySQLScanFunction();
 };
 
+class MySQLQueryFunction : public TableFunction {
+public:
+	MySQLQueryFunction();
+};
+
 class MySQLClearCacheFunction : public TableFunction {
 public:
 	MySQLClearCacheFunction();

--- a/src/include/mysql_utils.hpp
+++ b/src/include/mysql_utils.hpp
@@ -47,6 +47,7 @@ public:
 
 	static LogicalType ToMySQLType(const LogicalType &input);
 	static LogicalType TypeToLogicalType(ClientContext &context, const MySQLTypeData &input);
+	static LogicalType FieldToLogicalType(ClientContext &context, MYSQL_FIELD *field);
 	static string TypeToString(const LogicalType &input);
 
 	static string WriteIdentifier(const string &identifier);

--- a/src/mysql_extension.cpp
+++ b/src/mysql_extension.cpp
@@ -24,6 +24,9 @@ static void LoadInternal(DatabaseInstance &db) {
 	MySQLClearCacheFunction clear_cache_func;
 	ExtensionUtil::RegisterFunction(db, clear_cache_func);
 
+	MySQLQueryFunction query_function;
+	ExtensionUtil::RegisterFunction(db, query_function);
+
 	auto &config = DBConfig::GetConfig(db);
 	config.storage_extensions["mysql_scanner"] = make_uniq<MySQLStorageExtension>();
 

--- a/src/mysql_scanner.cpp
+++ b/src/mysql_scanner.cpp
@@ -7,6 +7,8 @@
 #include "storage/mysql_transaction.hpp"
 #include "storage/mysql_table_set.hpp"
 #include "mysql_filter_pushdown.hpp"
+#include "duckdb/main/database_manager.hpp"
+#include "duckdb/main/attached_database.hpp"
 
 namespace duckdb {
 
@@ -164,6 +166,84 @@ MySQLScanFunction::MySQLScanFunction()
 	serialize = MySQLScanSerialize;
 	deserialize = MySQLScanDeserialize;
 	projection_pushdown = true;
+}
+
+//===--------------------------------------------------------------------===//
+// MySQL Query
+//===--------------------------------------------------------------------===//
+struct MySQLQueryBindData : public FunctionData {
+	MySQLQueryBindData(Catalog &catalog, unique_ptr<MySQLResult> result_p, string query_p) :
+	   catalog(catalog), result(std::move(result_p)), query(std::move(query_p)) {
+	}
+
+	Catalog &catalog;
+	unique_ptr<MySQLResult> result;
+	string query;
+
+public:
+	unique_ptr<FunctionData> Copy() const override {
+		throw NotImplementedException("MySQLBindData copy not supported");
+	}
+	bool Equals(const FunctionData &other_p) const override {
+		return false;
+	}
+};
+
+static unique_ptr<FunctionData> MySQLQueryBind(ClientContext &context, TableFunctionBindInput &input,
+										  vector<LogicalType> &return_types, vector<string> &names) {
+	if (input.inputs[0].IsNull() || input.inputs[1].IsNull()) {
+		throw BinderException("Parameters to mysql_query cannot be NULL");
+	}
+
+	// look up the database to query
+	auto db_name = input.inputs[0].GetValue<string>();
+	auto &db_manager = DatabaseManager::Get(context);
+	auto db = db_manager.GetDatabase(context, db_name);
+	if (!db) {
+		throw BinderException("Failed to find attached database \"%s\" referenced in mysql_query", db_name);
+	}
+	auto &catalog = db->GetCatalog();
+	if (catalog.GetCatalogType() != "mysql") {
+		throw BinderException("Attached database \"%s\" does not refer to a MySQL database", db_name);
+	}
+	auto &transaction = MySQLTransaction::Get(context, catalog);
+	auto sql = input.inputs[1].GetValue<string>();
+	auto result = transaction.GetConnection().Query(sql, &context);
+	for(auto &field : result->Fields()) {
+		names.push_back(field.name);
+		return_types.push_back(field.type);
+	}
+	return make_uniq<MySQLQueryBindData>(catalog, std::move(result), std::move(sql));
+}
+
+static unique_ptr<GlobalTableFunctionState> MySQLQueryInitGlobalState(ClientContext &context,
+																 TableFunctionInitInput &input) {
+	auto &bind_data = input.bind_data->CastNoConst<MySQLQueryBindData>();
+	unique_ptr<MySQLResult> mysql_result;
+	if (bind_data.result) {
+		mysql_result = std::move(bind_data.result);
+	} else {
+		auto &transaction = MySQLTransaction::Get(context, bind_data.catalog);
+		mysql_result = transaction.GetConnection().Query(bind_data.query, &context);
+	}
+	auto column_count = mysql_result->ColumnCount();
+
+	auto result = make_uniq<MySQLGlobalState>(std::move(mysql_result));
+
+	// generate the varchar chunk
+	vector<LogicalType> varchar_types;
+	for (idx_t c = 0; c < column_count; c++) {
+		varchar_types.push_back(LogicalType::VARCHAR);
+	}
+	result->varchar_chunk.Initialize(Allocator::DefaultAllocator(), varchar_types);
+	return std::move(result);
+}
+
+MySQLQueryFunction::MySQLQueryFunction()
+	: TableFunction("mysql_query", {LogicalType::VARCHAR, LogicalType::VARCHAR}, MySQLScan,
+					MySQLQueryBind, MySQLQueryInitGlobalState, MySQLInitLocalState) {
+	serialize = MySQLScanSerialize;
+	deserialize = MySQLScanDeserialize;
 }
 
 } // namespace duckdb

--- a/src/mysql_utils.cpp
+++ b/src/mysql_utils.cpp
@@ -173,6 +173,89 @@ LogicalType MySQLUtils::TypeToLogicalType(ClientContext &context, const MySQLTyp
 	return LogicalType::VARCHAR;
 }
 
+LogicalType MySQLUtils::FieldToLogicalType(ClientContext &context, MYSQL_FIELD *field) {
+	MySQLTypeData type_data;
+	switch(field->type) {
+	case MYSQL_TYPE_TINY:
+		type_data.type_name = "tinyint";
+		break;
+	case MYSQL_TYPE_SHORT:
+		type_data.type_name = "smallint";
+		break;
+	case MYSQL_TYPE_INT24:
+		type_data.type_name = "mediumint";
+		break;
+	case MYSQL_TYPE_LONG:
+		type_data.type_name = "int";
+		break;
+	case MYSQL_TYPE_LONGLONG:
+		type_data.type_name = "bigint";
+		break;
+	case MYSQL_TYPE_FLOAT:
+		type_data.type_name = "float";
+		break;
+	case MYSQL_TYPE_DOUBLE:
+		type_data.type_name = "double";
+		break;
+	case MYSQL_TYPE_DECIMAL:
+	case MYSQL_TYPE_NEWDECIMAL:
+		type_data.precision = int64_t(field->max_length) - 2; // -2 for minus sign and dot
+		type_data.scale = field->decimals;
+		type_data.type_name = "decimal";
+		break;
+	case MYSQL_TYPE_TIMESTAMP:
+		type_data.type_name = "timestamp";
+		break;
+	case MYSQL_TYPE_DATE:
+		type_data.type_name = "date";
+		break;
+	case MYSQL_TYPE_TIME:
+		type_data.type_name = "time";
+		break;
+	case MYSQL_TYPE_DATETIME:
+		type_data.type_name = "datetime";
+		break;
+	case MYSQL_TYPE_YEAR:
+		type_data.type_name = "year";
+		break;
+	case MYSQL_TYPE_BIT:
+		type_data.type_name = "bit";
+		break;
+	case MYSQL_TYPE_GEOMETRY:
+		type_data.type_name = "geometry";
+		break;
+	case MYSQL_TYPE_NULL:
+		type_data.type_name = "null";
+		break;
+	case MYSQL_TYPE_SET:
+		type_data.type_name = "set";
+		break;
+	case MYSQL_TYPE_ENUM:
+		type_data.type_name = "enum";
+		break;
+	case MYSQL_TYPE_BLOB:
+	case MYSQL_TYPE_STRING:
+	case MYSQL_TYPE_VAR_STRING:
+		if (field->flags & BINARY_FLAG) {
+			type_data.type_name = "blob";
+		} else {
+			type_data.type_name = "varchar";
+		}
+		break;
+	default:
+		type_data.type_name = "__unknown_type";
+		break;
+	}
+	type_data.column_type = type_data.type_name;
+	if (field->max_length != 0) {
+		type_data.column_type += "(" + std::to_string(field->max_length) + ")";
+	}
+	if (field->flags & UNSIGNED_FLAG && field->flags & NUM_FLAG) {
+		type_data.column_type += " unsigned";
+	}
+	return MySQLUtils::TypeToLogicalType(context, type_data);
+}
+
 LogicalType MySQLUtils::ToMySQLType(const LogicalType &input) {
 	switch (input.id()) {
 	case LogicalTypeId::BOOLEAN:

--- a/test/sql/mysql_query.test
+++ b/test/sql/mysql_query.test
@@ -100,14 +100,6 @@ SELECT * FROM mysql_query('simple', 'SELECT * FROM bits')
 false	\x00\x00\x00\x00\x00\x01UU
 NULL	NULL
 
-query IIIII
-SELECT * FROM mysql_query('simple', 'SELECT * FROM datetime_tbl')
-----
-2020-02-03	2029-02-14 08:47:23	2029-02-14 14:47:23+00	23:59:59	1901
-1000-01-01	1000-01-01 00:00:00	1970-01-01 06:00:01+00	-838:59:59	2155
-9999-12-31	9999-12-31 23:59:59	2038-01-19 04:14:07+00	838:59:59	2000
-NULL	NULL	NULL	NULL	NULL
-
 query III
 SELECT * FROM mysql_query('simple', 'SELECT * FROM text_tbl')
 ----
@@ -160,3 +152,16 @@ statement error
 SELECT * FROM mysql_query('simple', 'SELECT 42 a, 42 a')
 ----
 duplicate column
+
+require icu
+
+statement ok
+SET TimeZone='UTC'
+
+query IIIII
+SELECT * FROM mysql_query('simple', 'SELECT * FROM datetime_tbl')
+----
+2020-02-03	2029-02-14 08:47:23	2029-02-14 14:47:23+00	23:59:59	1901
+1000-01-01	1000-01-01 00:00:00	1970-01-01 06:00:01+00	-838:59:59	2155
+9999-12-31	9999-12-31 23:59:59	2038-01-19 04:14:07+00	838:59:59	2000
+NULL	NULL	NULL	NULL	NULL

--- a/test/sql/mysql_query.test
+++ b/test/sql/mysql_query.test
@@ -1,0 +1,162 @@
+# name: test/sql/mysql_query.test
+# description: Test mysql_query
+# group: [sql]
+
+require mysql_scanner
+
+require-env MYSQL_TEST_DATABASE_AVAILABLE
+
+statement ok
+ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS simple (TYPE MYSQL_SCANNER)
+
+# simple example
+query I
+SELECT * FROM mysql_query('simple', 'SELECT 42')
+----
+42
+
+query I
+SELECT col FROM mysql_query('simple', 'SELECT 42 AS col')
+----
+42
+
+query I
+SELECT * FROM mysql_query('simple', 'SELECT NULL')
+----
+NULL
+
+# test many types
+query I
+SELECT typeof(COLUMNS(*)) FROM mysql_query('simple', 'SELECT * FROM booleans') LIMIT 1
+----
+BOOLEAN
+
+query I
+SELECT * FROM mysql_query('simple', 'SELECT * FROM booleans')
+----
+false
+true
+NULL
+
+query IIIII
+SELECT typeof(COLUMNS(*)) FROM mysql_query('simple', 'SELECT * FROM signed_integers') LIMIT 1
+----
+TINYINT	SMALLINT	INTEGER	INTEGER	BIGINT
+
+query IIIII
+SELECT * FROM mysql_query('simple', 'SELECT * FROM signed_integers')
+----
+-128	-32768	-8388608	-2147483648	-9223372036854775808
+127	32767	8388607	2147483647	9223372036854775807
+NULL	NULL	NULL	NULL	NULL
+
+query IIIII
+SELECT typeof(COLUMNS(*)) FROM mysql_query('simple', 'SELECT * FROM unsigned_integers') LIMIT 1
+----
+UTINYINT	USMALLINT	UINTEGER	UINTEGER	UBIGINT
+
+query IIIII
+SELECT * FROM mysql_query('simple', 'SELECT * FROM unsigned_integers')
+----
+0	0	0	0	0
+255	65535	16777215	4294967295	18446744073709551615
+NULL	NULL	NULL	NULL	NULL
+
+query IIII
+SELECT typeof(COLUMNS(*)) FROM mysql_query('simple', 'SELECT * FROM floating_points') LIMIT 1
+----
+FLOAT	DOUBLE	FLOAT	DOUBLE
+
+query IIII
+SELECT * FROM mysql_query('simple', 'SELECT * FROM floating_points')
+----
+0.0	0.0	0.0	0.0
+0.5	0.5	0.5	0.5
+-0.5	-0.5	0.0	0.0
+NULL	NULL	NULL	NULL
+
+query IIIII
+SELECT * FROM mysql_query('simple', 'SELECT * FROM decimals')
+----
+0.5	1234.1	12345678.12	12345678901234567.123	1.2345678901234568e+35
+-0.5	-1234.1	-12345678.12	-12345678901234567.123	-1.2345678901234568e+35
+NULL	NULL	NULL	NULL	NULL
+
+query IIIII
+SELECT typeof(COLUMNS(*)) FROM mysql_query('simple', 'SELECT * FROM decimals') LIMIT 1
+----
+DECIMAL(2,1)	DECIMAL(5,1)	DECIMAL(10,2)	DECIMAL(20,3)	DOUBLE
+
+query II
+SELECT * FROM mysql_query('simple', 'SELECT * FROM fake_booleans')
+----
+true	true
+false	false
+NULL	NULL
+
+query II
+SELECT * FROM mysql_query('simple', 'SELECT * FROM bits')
+----
+false	\x00\x00\x00\x00\x00\x01UU
+NULL	NULL
+
+query IIIII
+SELECT * FROM mysql_query('simple', 'SELECT * FROM datetime_tbl')
+----
+2020-02-03	2029-02-14 08:47:23	2029-02-14 14:47:23+00	23:59:59	1901
+1000-01-01	1000-01-01 00:00:00	1970-01-01 06:00:01+00	-838:59:59	2155
+9999-12-31	9999-12-31 23:59:59	2038-01-19 04:14:07+00	838:59:59	2000
+NULL	NULL	NULL	NULL	NULL
+
+query III
+SELECT * FROM mysql_query('simple', 'SELECT * FROM text_tbl')
+----
+ab  	ab	thisisalongstring
+(empty)	(empty)	(empty)
+🦆	🦆	🦆🦆🦆🦆
+NULL	NULL	NULL
+
+query III
+SELECT * FROM mysql_query('simple', 'SELECT * FROM blob_tbl')
+----
+c\x00\x00\x00	c\x00\x00	c\x00\x00
+\x00\x00\x00\x00	(empty)	(empty)
+\x80\x00\x00\x00	\x80	\x80
+NULL	NULL	NULL
+
+query I
+SELECT * FROM mysql_query('simple', 'SELECT * FROM enum_tbl')
+----
+x-small
+small
+medium
+large
+x-large
+NULL
+
+query I
+SELECT * FROM mysql_query('simple', 'SELECT * FROM set_tbl')
+----
+a,d
+a,d
+a,d
+a,d
+a,d
+
+query I
+SELECT * FROM mysql_query('simple', 'SELECT * FROM json_tbl')
+----
+{"k1": "value", "k2": 10}
+["abc", 10, null, true, false]
+NULL
+
+# errors
+statement error
+SELECT * FROM mysql_query('simple', 'SELEC 42')
+----
+Failed to run query
+
+statement error
+SELECT * FROM mysql_query('simple', 'SELECT 42 a, 42 a')
+----
+duplicate column


### PR DESCRIPTION
Implements #35

Usage:

```sql
ATTACH 'host=localhost user=root port=0 database=mysqlscanner' AS simple (TYPE MYSQL_SCANNER)
SELECT * FROM mysql_query('simple', 'SELECT 42')
```