### PR TITLE
Fallback to reading configuration from environment variables

### DIFF
--- a/src/mysql_utils.cpp
+++ b/src/mysql_utils.cpp
@@ -137,7 +137,7 @@ MySQLConnectionParameters MySQLUtils::ParseConnectionParameters(const string &ds
 	}
 	if (set_options.find("port") == set_options.end()) {
 		string port_number;
-		if (ReadOptionFromEnv("MYSQL_UNIX_PORT", port_number)) {
+		if (ReadOptionFromEnv("MYSQLX_TCP_PORT", port_number)) {
 			result.port = ParsePort(port_number);
 		}
 	}

--- a/src/mysql_utils.cpp
+++ b/src/mysql_utils.cpp
@@ -137,7 +137,7 @@ MySQLConnectionParameters MySQLUtils::ParseConnectionParameters(const string &ds
 	}
 	if (set_options.find("port") == set_options.end()) {
 		string port_number;
-		if (ReadOptionFromEnv("MYSQLX_TCP_PORT", port_number)) {
+		if (ReadOptionFromEnv("MYSQL_TCP_PORT", port_number)) {
 			result.port = ParsePort(port_number);
 		}
 	}


### PR DESCRIPTION
Partially implements #41

This PR adds support for reading configuration from [MySQL standard environment variables](https://dev.mysql.com/doc/refman/8.3/en/environment-variables.html). If no option is provided explicitly, we try to read it from the following environment variables instead:

| Setting  |   Env    |
|----------|--------------|
| host     | MYSQL_HOST    |
| user     | MYSQL_USER |
| password |    MYSQL_PWD          |
| database | MYSQL_DATABASE         |
| port     | MYSQL_TCP_PORT            |
| socket   | MYSQL_UNIX_PORT         |

