### PR TITLE
Add `workload` param to MySQL connection string

### DIFF
--- a/src/include/mysql_utils.hpp
+++ b/src/include/mysql_utils.hpp
@@ -37,6 +37,7 @@ struct MySQLConnectionParameters {
 	string db;
 	uint32_t port = 0;
 	string unix_socket;
+	string workload;
 	idx_t client_flag = CLIENT_COMPRESS | CLIENT_IGNORE_SIGPIPE | CLIENT_MULTI_STATEMENTS;
 };
 

--- a/src/mysql_utils.cpp
+++ b/src/mysql_utils.cpp
@@ -158,10 +158,10 @@ MYSQL *MySQLUtils::Connect(const string &dsn) {
 	if (!config.workload.empty()) {
 		workload_param = "workload=" + config.workload;
 	}
-	string db_with_workload = config.host;
+	string db_with_workload = config.db;
 	if (!workload_param.empty()) {
 		if (db_with_workload.find('?') != string::npos) {
-			db_with_workload += "&" + workload_param.substr(1);
+			db_with_workload += "&" + workload_param;
 		} else {
 			db_with_workload += "?" + workload_param;
 		}


### PR DESCRIPTION
For MySQL users with single-query row limits (i.e. Vitess and/or Planetscale users), the workload session variable allows them to bypass the 100,000 row limit so that DuckDB can properly load tables into memory and/or on disk without manually having to write batch queries to create a table in DuckDB from a table of 100s of thousands or millions of rows.