### PR TITLE
Fix backslash encoding in a better way

### DIFF
--- a/src/mysql_connection.cpp
+++ b/src/mysql_connection.cpp
@@ -31,7 +31,6 @@ MySQLConnection MySQLConnection::Open(const string &connection_string) {
 	result.connection = make_shared<OwnedMySQLConnection>(MySQLUtils::Connect(connection_string));
 	result.dsn = connection_string;
 	result.Execute("SET character_set_results = 'utf8mb4';");
-	result.Execute("SET sql_mode = 'no_backslash_escapes';");
 	return result;
 }
 

--- a/src/mysql_utils.cpp
+++ b/src/mysql_utils.cpp
@@ -404,7 +404,18 @@ LogicalType MySQLUtils::ToMySQLType(const LogicalType &input) {
 }
 
 string MySQLUtils::EscapeQuotes(const string &text, char quote) {
-	return StringUtil::Replace(text, string(1, quote), string("\\") + string(1, quote));
+	string result;
+	for(idx_t i = 0; i < text.size(); i++) {
+		if (text[i] == quote) {
+			result += "\\";
+			result += quote;
+		} else if (text[i] == '\\') {
+			result += "\\\\";
+		} else {
+			result += text[i];
+		}
+	}
+	return result;
 }
 
 string MySQLUtils::WriteQuoted(const string &text, char quote) {


### PR DESCRIPTION
Correctly escape backslashes instead of setting `no_backslash_escapes`