### PR TITLE
Implement credential management using secrets

### DIFF
--- a/src/include/mysql_result.hpp
+++ b/src/include/mysql_result.hpp
@@ -63,7 +63,8 @@ public:
 	}
 	idx_t AffectedRows() {
 		if (affected_rows == idx_t(-1)) {
-			throw InternalException("MySQLResult::AffectedRows called for result that didn't affect any rows");
+			throw InternalException("MySQLResult::AffectedRows called for result "
+			                        "that didn't affect any rows");
 		}
 		return affected_rows;
 	}

--- a/src/mysql_execute.cpp
+++ b/src/mysql_execute.cpp
@@ -12,7 +12,7 @@ namespace duckdb {
 
 struct MySQLExecuteBindData : public TableFunctionData {
 	explicit MySQLExecuteBindData(MySQLCatalog &mysql_catalog, string query_p)
-		: mysql_catalog(mysql_catalog), query(std::move(query_p)) {
+	    : mysql_catalog(mysql_catalog), query(std::move(query_p)) {
 	}
 
 	bool finished = false;
@@ -21,7 +21,7 @@ struct MySQLExecuteBindData : public TableFunctionData {
 };
 
 static duckdb::unique_ptr<FunctionData> MySQLExecuteBind(ClientContext &context, TableFunctionBindInput &input,
-													  vector<LogicalType> &return_types, vector<string> &names) {
+                                                         vector<LogicalType> &return_types, vector<string> &names) {
 	return_types.emplace_back(LogicalType::BOOLEAN);
 	names.emplace_back("Success");
 
@@ -54,8 +54,7 @@ static void MySQLExecuteFunc(ClientContext &context, TableFunctionInput &data_p,
 }
 
 MySQLExecuteFunction::MySQLExecuteFunction()
-	: TableFunction("mysql_execute", {LogicalType::VARCHAR, LogicalType::VARCHAR}, MySQLExecuteFunc,
-					MySQLExecuteBind) {
+    : TableFunction("mysql_execute", {LogicalType::VARCHAR, LogicalType::VARCHAR}, MySQLExecuteFunc, MySQLExecuteBind) {
 }
 
 } // namespace duckdb

--- a/src/mysql_scanner.cpp
+++ b/src/mysql_scanner.cpp
@@ -93,7 +93,8 @@ void CastBoolFromMySQL(ClientContext &context, Vector &input, Vector &result, id
 		auto str_data = input_data[r].GetData();
 		auto str_size = input_data[r].GetSize();
 		if (str_size != 1) {
-			throw BinderException("Failed to cast MySQL boolean - expected 1 byte element but got element of size %s",
+			throw BinderException("Failed to cast MySQL boolean - expected 1 byte "
+			                      "element but got element of size %s",
 			                      str_size);
 		}
 		auto bool_char = *str_data;
@@ -132,7 +133,8 @@ static void MySQLScan(ClientContext &context, TableFunctionInput &data, DataChun
 			output.data[c].Reinterpret(gstate.varchar_chunk.data[c]);
 			break;
 		case LogicalTypeId::BOOLEAN:
-			// booleans can be sent either as numbers ('0' or '1') or as bits ('\0' or '\1')
+			// booleans can be sent either as numbers ('0' or '1') or as bits ('\0' or
+			// '\1')
 			CastBoolFromMySQL(context, gstate.varchar_chunk.data[c], output.data[c], r);
 			break;
 		default: {

--- a/src/mysql_storage.cpp
+++ b/src/mysql_storage.cpp
@@ -4,12 +4,100 @@
 #include "storage/mysql_catalog.hpp"
 #include "duckdb/parser/parsed_data/attach_info.hpp"
 #include "storage/mysql_transaction_manager.hpp"
+#include "duckdb/main/secret/secret_manager.hpp"
 
 namespace duckdb {
 
+string EscapeConnectionString(const string &input) {
+	string result = "\"";
+	for (auto c : input) {
+		if (c == '\\') {
+			result += "\\\\";
+		} else if (c == '"') {
+			result += "\\\"";
+		} else {
+			result += c;
+		}
+	}
+	result += "\"";
+	return result;
+}
+
+string AddConnectionOption(const KeyValueSecret &kv_secret, const string &name) {
+	Value input_val = kv_secret.TryGetValue(name);
+	if (input_val.IsNull()) {
+		// not provided
+		return string();
+	}
+	string result;
+	result += name;
+	result += "=";
+	result += EscapeConnectionString(input_val.ToString());
+	result += " ";
+	return result;
+}
+
+unique_ptr<SecretEntry> GetSecret(ClientContext &context, const string &secret_name) {
+	auto &secret_manager = SecretManager::Get(context);
+	auto transaction = CatalogTransaction::GetSystemCatalogTransaction(context);
+	// FIXME: this should be adjusted once the `GetSecretByName` API supports this
+	// use case
+	auto secret_entry = secret_manager.GetSecretByName(transaction, secret_name, "memory");
+	if (secret_entry) {
+		return secret_entry;
+	}
+	secret_entry = secret_manager.GetSecretByName(transaction, secret_name, "local_file");
+	if (secret_entry) {
+		return secret_entry;
+	}
+	return nullptr;
+}
+
 static unique_ptr<Catalog> MySQLAttach(StorageExtensionInfo *storage_info, ClientContext &context, AttachedDatabase &db,
                                        const string &name, AttachInfo &info, AccessMode access_mode) {
-	return make_uniq<MySQLCatalog>(db, info.path, access_mode);
+	// check if we have a secret provided
+	string secret_name;
+	for (auto &entry : info.options) {
+		auto lower_name = StringUtil::Lower(entry.first);
+		if (lower_name == "type" || lower_name == "read_only") {
+			// already handled
+		} else if (lower_name == "secret") {
+			secret_name = entry.second.ToString();
+		} else {
+			throw BinderException("Unrecognized option for MySQL attach: %s", entry.first);
+		}
+	}
+
+	// if no secret is specified we default to the unnamed mysql secret, if it
+	// exists
+	bool explicit_secret = !secret_name.empty();
+	if (!explicit_secret) {
+		// look up settings from the default unnamed mysql secret if none is
+		// provided
+		secret_name = "__default_mysql";
+	}
+
+	string connection_string = info.path;
+	auto secret_entry = GetSecret(context, secret_name);
+	if (secret_entry) {
+		// secret found - read data
+		const auto &kv_secret = dynamic_cast<const KeyValueSecret &>(*secret_entry->secret);
+		string new_connection_info;
+
+		new_connection_info += AddConnectionOption(kv_secret, "user");
+		new_connection_info += AddConnectionOption(kv_secret, "password");
+		new_connection_info += AddConnectionOption(kv_secret, "host");
+		new_connection_info += AddConnectionOption(kv_secret, "port");
+		new_connection_info += AddConnectionOption(kv_secret, "database");
+		new_connection_info += AddConnectionOption(kv_secret, "socket");
+
+		connection_string = new_connection_info + connection_string;
+	} else if (explicit_secret) {
+		// secret not found and one was explicitly provided - throw an error
+		throw BinderException("Secret with name \"%s\" not found", secret_name);
+	}
+
+	return make_uniq<MySQLCatalog>(db, connection_string, access_mode);
 }
 
 static unique_ptr<TransactionManager> MySQLCreateTransactionManager(StorageExtensionInfo *storage_info,

--- a/src/mysql_utils.cpp
+++ b/src/mysql_utils.cpp
@@ -69,8 +69,7 @@ uint32_t ParsePort(const string &value) {
 	constexpr const static int PORT_MAX = 65353;
 	int port_val = std::stoi(value);
 	if (port_val < PORT_MIN || port_val > PORT_MAX) {
-		throw InvalidInputException("Invalid port %d - port must be between %d and %d", port_val, PORT_MIN,
-									PORT_MAX);
+		throw InvalidInputException("Invalid port %d - port must be between %d and %d", port_val, PORT_MIN, PORT_MAX);
 	}
 	return uint32_t(port_val);
 }
@@ -114,7 +113,8 @@ MySQLConnectionParameters MySQLUtils::ParseConnectionParameters(const string &ds
 			set_options.insert("socket");
 			result.unix_socket = value;
 		} else {
-			throw InvalidInputException("Unrecognized configuration parameter \"%s\" - expected options are host, "
+			throw InvalidInputException("Unrecognized configuration parameter \"%s\" "
+			                            "- expected options are host, "
 			                            "user, passwd, db, port, socket",
 			                            key);
 		}
@@ -233,11 +233,12 @@ LogicalType MySQLUtils::TypeToLogicalType(ClientContext &context, const MySQLTyp
 	} else if (type_info.type_name == "date") {
 		return LogicalType::DATE;
 	} else if (type_info.type_name == "time") {
-		// we need to convert time to VARCHAR because TIME in MySQL is more like an interval and can store ranges
-		// between -838:00:00 to 838:00:00
+		// we need to convert time to VARCHAR because TIME in MySQL is more like an
+		// interval and can store ranges between -838:00:00 to 838:00:00
 		return LogicalType::VARCHAR;
 	} else if (type_info.type_name == "timestamp") {
-		// in MySQL, "timestamp" columns are timezone aware while "datetime" columns are not
+		// in MySQL, "timestamp" columns are timezone aware while "datetime" columns
+		// are not
 		return LogicalType::TIMESTAMP_TZ;
 	} else if (type_info.type_name == "year") {
 		return LogicalType::INTEGER;
@@ -405,7 +406,7 @@ LogicalType MySQLUtils::ToMySQLType(const LogicalType &input) {
 
 string MySQLUtils::EscapeQuotes(const string &text, char quote) {
 	string result;
-	for(auto c : text) {
+	for (auto c : text) {
 		if (c == quote) {
 			result += "\\";
 			result += quote;

--- a/src/storage/mysql_catalog.cpp
+++ b/src/storage/mysql_catalog.cpp
@@ -46,8 +46,8 @@ optional_ptr<SchemaCatalogEntry> MySQLCatalog::GetSchema(CatalogTransaction tran
                                                          QueryErrorContext error_context) {
 	if (schema_name == DEFAULT_SCHEMA) {
 		if (default_schema.empty()) {
-			throw InvalidInputException(
-			    "Attempting to fetch the default schema - but no database was provided in the connection string");
+			throw InvalidInputException("Attempting to fetch the default schema - but no database was "
+			                            "provided in the connection string");
 		}
 		return GetSchema(transaction, default_schema, if_not_found, error_context);
 	}
@@ -68,8 +68,8 @@ string MySQLCatalog::GetDBPath() {
 
 DatabaseSize MySQLCatalog::GetDatabaseSize(ClientContext &context) {
 	if (default_schema.empty()) {
-		throw InvalidInputException(
-		    "Attempting to fetch the database size - but no database was provided in the connection string");
+		throw InvalidInputException("Attempting to fetch the database size - but no database was provided "
+		                            "in the connection string");
 	}
 	auto &postgres_transaction = MySQLTransaction::Get(context, *this);
 	auto query = StringUtil::Replace(R"(

--- a/src/storage/mysql_execute_query.cpp
+++ b/src/storage/mysql_execute_query.cpp
@@ -79,8 +79,8 @@ string MySQLExecuteQuery::ParamsToString() const {
 // Plan
 //===--------------------------------------------------------------------===//
 string ExtractFilters(PhysicalOperator &child, const string &statement) {
-	// FIXME - all of this is pretty gnarly, we should provide a hook earlier on in the planning process to convert this
-	// into a SQL statement
+	// FIXME - all of this is pretty gnarly, we should provide a hook earlier on
+	// in the planning process to convert this into a SQL statement
 	if (child.type == PhysicalOperatorType::FILTER) {
 		auto &filter = child.Cast<PhysicalFilter>();
 		auto result = ExtractFilters(*child.children[0], statement);
@@ -97,7 +97,8 @@ string ExtractFilters(PhysicalOperator &child, const string &statement) {
 		}
 		throw NotImplementedException("Pushed down table filters not supported currently");
 	} else {
-		throw NotImplementedException("Unsupported operator type %s in %s statement - only simple deletes (e.g. %s "
+		throw NotImplementedException("Unsupported operator type %s in %s statement - only simple deletes "
+		                              "(e.g. %s "
 		                              "FROM tbl WHERE x=y) are supported in the MySQL connector",
 		                              PhysicalOperatorToString(child.type), statement, statement);
 	}
@@ -127,16 +128,16 @@ unique_ptr<PhysicalOperator> MySQLCatalog::PlanDelete(ClientContext &context, Lo
 }
 
 string ConstructUpdateStatement(LogicalUpdate &op, PhysicalOperator &child) {
-	// FIXME - all of this is pretty gnarly, we should provide a hook earlier on in the planning process to convert this
-	// into a SQL statement
+	// FIXME - all of this is pretty gnarly, we should provide a hook earlier on
+	// in the planning process to convert this into a SQL statement
 	string result = "UPDATE";
 	result += MySQLUtils::WriteIdentifier(op.table.schema.name);
 	result += ".";
 	result += MySQLUtils::WriteIdentifier(op.table.name);
 	result += " SET ";
 	if (child.type != PhysicalOperatorType::PROJECTION) {
-		throw NotImplementedException(
-		    "MySQL Update not supported - Expected the child of an update to be a projection");
+		throw NotImplementedException("MySQL Update not supported - Expected the "
+		                              "child of an update to be a projection");
 	}
 	auto &proj = child.Cast<PhysicalProjection>();
 	for (idx_t c = 0; c < op.columns.size(); c++) {

--- a/src/storage/mysql_schema_entry.cpp
+++ b/src/storage/mysql_schema_entry.cpp
@@ -116,7 +116,8 @@ string GetMySQLCreateView(CreateViewInfo &info) {
 
 optional_ptr<CatalogEntry> MySQLSchemaEntry::CreateView(CatalogTransaction transaction, CreateViewInfo &info) {
 	if (info.sql.empty()) {
-		throw BinderException("Cannot create view in MySQL that originated from an empty SQL statement");
+		throw BinderException("Cannot create view in MySQL that originated from an "
+		                      "empty SQL statement");
 	}
 	if (info.on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT ||
 	    info.on_conflict == OnCreateConflict::IGNORE_ON_CONFLICT) {

--- a/src/storage/mysql_table_set.cpp
+++ b/src/storage/mysql_table_set.cpp
@@ -110,13 +110,15 @@ optional_ptr<CatalogEntry> MySQLTableSet::RefreshTable(ClientContext &context, c
 	return table_ptr;
 }
 
-// FIXME - this is almost entirely copied from TableCatalogEntry::ColumnsToSQL - should be unified
+// FIXME - this is almost entirely copied from TableCatalogEntry::ColumnsToSQL -
+// should be unified
 string MySQLColumnsToSQL(const ColumnList &columns, const vector<unique_ptr<Constraint>> &constraints) {
 	std::stringstream ss;
 
 	ss << "(";
 
-	// find all columns that have NOT NULL specified, but are NOT primary key columns
+	// find all columns that have NOT NULL specified, but are NOT primary key
+	// columns
 	logical_index_set_t not_null_columns;
 	logical_index_set_t unique_columns;
 	logical_index_set_t pk_columns;
@@ -137,7 +139,8 @@ string MySQLColumnsToSQL(const ColumnList &columns, const vector<unique_ptr<Cons
 					unique_columns.insert(pk.index);
 				}
 			} else {
-				// multi-column constraint, this constraint needs to go at the end after all columns
+				// multi-column constraint, this constraint needs to go at the end after
+				// all columns
 				if (pk.is_primary_key) {
 					// multi key pk column: insert set of columns into multi_key_pks
 					for (auto &col : pk.columns) {
@@ -286,7 +289,8 @@ void MySQLTableSet::AlterTable(ClientContext &context, AlterTableInfo &alter) {
 		AlterTable(context, alter.Cast<RemoveColumnInfo>());
 		break;
 	default:
-		throw BinderException("Unsupported ALTER TABLE type - MySQL tables only support RENAME TABLE, RENAME COLUMN, "
+		throw BinderException("Unsupported ALTER TABLE type - MySQL tables only "
+		                      "support RENAME TABLE, RENAME COLUMN, "
 		                      "ADD COLUMN and DROP COLUMN");
 	}
 	ClearEntries();

--- a/src/storage/mysql_transaction.cpp
+++ b/src/storage/mysql_transaction.cpp
@@ -55,7 +55,6 @@ unique_ptr<MySQLResult> MySQLTransaction::Query(const string &query) {
 	return connection.Query(query);
 }
 
-
 MySQLTransaction &MySQLTransaction::Get(ClientContext &context, Catalog &catalog) {
 	return Transaction::Get(context, catalog).Cast<MySQLTransaction>();
 }

--- a/test/sql/attach_secret.test
+++ b/test/sql/attach_secret.test
@@ -1,0 +1,74 @@
+# name: test/sql/attach_secret.test
+# description: Test attaching using a secret
+# group: [storage]
+
+require mysql_scanner
+
+require-env MYSQL_TEST_DATABASE_AVAILABLE
+
+statement ok
+PRAGMA enable_verification
+
+# attach using default secret
+statement ok
+CREATE SECRET (
+	TYPE MYSQL,
+	HOST localhost,
+	USER root,
+	PORT 0,
+	DATABASE unknown_db
+);
+
+statement error
+ATTACH '' AS secret_attach (TYPE MYSQL)
+----
+unknown_db
+
+# attach using an explicit secret
+statement ok
+CREATE SECRET mysql_secret (
+	TYPE MYSQL,
+	HOST localhost,
+	USER root,
+	PORT 0,
+	DATABASE MYSQLSCANNER
+);
+
+statement ok
+ATTACH '' AS secret_attach (TYPE MYSQL, SECRET mysql_secret)
+
+statement ok
+DETACH secret_attach
+
+statement ok
+CREATE OR REPLACE SECRET mysql_secret (
+	TYPE MYSQL,
+	HOST localhost,
+	USER root,
+	PORT 0,
+	DATABASE unknown_db
+);
+
+# non-existent database
+statement error
+ATTACH '' AS secret_attach (TYPE MYSQL, SECRET mysql_secret)
+----
+unknown_db
+
+# we can override options in the attach string
+statement ok
+ATTACH 'database=mysqlscanner' AS secret_attach (TYPE MYSQL, SECRET mysql_secret)
+
+statement error
+CREATE SECRET new_secret (
+	TYPE MYSQL,
+	UNKNOWN_OPTION xx
+);
+----
+unknown_option
+
+# unknown secret
+statement error
+ATTACH '' AS secret_attach (TYPE MYSQL, SECRET unknown_secret)
+----
+unknown_secret


### PR DESCRIPTION
Implements the same as https://github.com/duckdb/postgres_scanner/pull/217 but for MySQL

This allows credentials to be managed using secrets. The secret to be used can be selected with the `SECRET` setting that is passed into `ATTACH`. There is also a default secret - this is the secret that is created without specifying a name. When no secret is provided to `ATTACH`, and such a secret is present, this secret is used.

Secrets can provide the following set of options.

|    Name    |             Description              |
|------------|--------------------------------------|
| `database` | Database name                     |
| `user`     | MySQL user name                   |
| `password` | MySQL password                    |
| `host`     | Name of host to connect to           |
| `port`     | Port number                          |
| `socket`     | Socket                          |

Note that not all of these need to be provided. For options that are not provided, the system falls back to the regular set of default options as specified [in the configuration](https://duckdb.org/docs/extensions/mysql#configuration).

##### Implicit (Default) Secret With All Options
```sql
CREATE SECRET (
	TYPE MYSQL,
	HOST '127.0.0.1',
        PORT 0,
	DATABASE mysqlscanner,
        USER 'mysql',
	PASSWORD ''
);
ATTACH '' AS secret_attach (TYPE MYSQL);
```

##### Explicit (Named) Secret With Limited Options
```sql
CREATE SECRET mysql_secret(
	TYPE MYSQL,
	HOST '127.0.0.1',
        PORT 0,
	DATABASE mysqlscanner,
        USER 'mysql',
	PASSWORD ''
);

ATTACH '' AS secret_attach (TYPE MYSQL, SECRET mysql_secret);
```

##### Overriding Options
Secrets essentially provide a new set of **default** options. The individual options can be overridden in the attach string, similar to how they can be overridden for the standard set of default options. For example:

```sql
CREATE SECRET (
	TYPE MYSQL,
	HOST '127.0.0.1',
        PORT 0,
	DATABASE mysqlscanner,
        USER 'mysql',
	PASSWORD ''
);
-- override the dbname option, but use the rest of the options provided in the secret
ATTACH 'dbname=unknown_db_name' AS secret_attach (TYPE MYSQL);
-- Unknown database 'unknown_db_name'
```


