### PR TITLE
Implement #71: add SSL connection parameters

### DIFF
--- a/src/include/mysql_utils.hpp
+++ b/src/include/mysql_utils.hpp
@@ -38,6 +38,14 @@ struct MySQLConnectionParameters {
 	uint32_t port = 0;
 	string unix_socket;
 	idx_t client_flag = CLIENT_COMPRESS | CLIENT_IGNORE_SIGPIPE | CLIENT_MULTI_STATEMENTS;
+	unsigned int ssl_mode = SSL_MODE_PREFERRED;
+	string ssl_ca;
+	string ssl_ca_path;
+	string ssl_cert;
+	string ssl_cipher;
+	string ssl_crl;
+	string ssl_crl_path;
+	string ssl_key;
 };
 
 class MySQLUtils {

--- a/src/mysql_extension.cpp
+++ b/src/mysql_extension.cpp
@@ -38,6 +38,24 @@ unique_ptr<BaseSecret> CreateMySQLSecretFunction(ClientContext &, CreateSecretIn
 			result->secret_map["port"] = named_param.second.ToString();
 		} else if (lower_name == "socket") {
 			result->secret_map["socket"] = named_param.second.ToString();
+		} else if (lower_name == "ssl_mode") {
+			result->secret_map["ssl_mode"] = named_param.second.ToString();
+		} else if (lower_name == "ssl_ca") {
+			result->secret_map["ssl_ca"] = named_param.second.ToString();
+		} else if (lower_name == "ssl_capath") {
+			result->secret_map["ssl_capath"] = named_param.second.ToString();
+		} else if (lower_name == "ssl_capath") {
+			result->secret_map["ssl_capath"] = named_param.second.ToString();
+		} else if (lower_name == "ssl_cert") {
+			result->secret_map["ssl_cert"] = named_param.second.ToString();
+		} else if (lower_name == "ssl_cipher") {
+			result->secret_map["ssl_cipher"] = named_param.second.ToString();
+		} else if (lower_name == "ssl_crl") {
+			result->secret_map["ssl_crl"] = named_param.second.ToString();
+		} else if (lower_name == "ssl_crlpath") {
+			result->secret_map["ssl_crlpath"] = named_param.second.ToString();
+		} else if (lower_name == "ssl_key") {
+			result->secret_map["ssl_key"] = named_param.second.ToString();
 		} else {
 			throw InternalException("Unknown named parameter passed to CreateMySQLSecretFunction: " + lower_name);
 		}
@@ -55,6 +73,14 @@ void SetMySQLSecretParameters(CreateSecretFunction &function) {
 	function.named_parameters["user"] = LogicalType::VARCHAR;
 	function.named_parameters["database"] = LogicalType::VARCHAR;
 	function.named_parameters["socket"] = LogicalType::VARCHAR;
+	function.named_parameters["ssl_mode"] = LogicalType::VARCHAR;
+	function.named_parameters["ssl_ca"] = LogicalType::VARCHAR;
+	function.named_parameters["ssl_capath"] = LogicalType::VARCHAR;
+	function.named_parameters["ssl_cert"] = LogicalType::VARCHAR;
+	function.named_parameters["ssl_cipher"] = LogicalType::VARCHAR;
+	function.named_parameters["ssl_crl"] = LogicalType::VARCHAR;
+	function.named_parameters["ssl_crlpath"] = LogicalType::VARCHAR;
+	function.named_parameters["ssl_key"] = LogicalType::VARCHAR;
 }
 
 static void LoadInternal(DatabaseInstance &db) {

--- a/src/mysql_storage.cpp
+++ b/src/mysql_storage.cpp
@@ -90,7 +90,14 @@ static unique_ptr<Catalog> MySQLAttach(StorageExtensionInfo *storage_info, Clien
 		new_connection_info += AddConnectionOption(kv_secret, "port");
 		new_connection_info += AddConnectionOption(kv_secret, "database");
 		new_connection_info += AddConnectionOption(kv_secret, "socket");
-
+		new_connection_info += AddConnectionOption(kv_secret, "ssl_mode");
+		new_connection_info += AddConnectionOption(kv_secret, "ssl_ca");
+		new_connection_info += AddConnectionOption(kv_secret, "ssl_capath");
+		new_connection_info += AddConnectionOption(kv_secret, "ssl_cert");
+		new_connection_info += AddConnectionOption(kv_secret, "ssl_cipher");
+		new_connection_info += AddConnectionOption(kv_secret, "ssl_crl");
+		new_connection_info += AddConnectionOption(kv_secret, "ssl_crlpath");
+		new_connection_info += AddConnectionOption(kv_secret, "ssl_key");
 		connection_string = new_connection_info + connection_string;
 	} else if (explicit_secret) {
 		// secret not found and one was explicitly provided - throw an error

--- a/test/sql/attach_ssl.test
+++ b/test/sql/attach_ssl.test
@@ -1,0 +1,17 @@
+# name: test/sql/attach_ssl.test
+# description: ATTACH with SSL parameters
+# group: [sql]
+
+require mysql_scanner
+
+require-env MYSQL_TEST_DATABASE_AVAILABLE
+
+# invalid ssl mode
+statement error
+ATTACH 'host=localhost user=root port=0 database=mysql ssl_mode=xxx' AS simple (TYPE MYSQL_SCANNER)
+----
+ssl mode must be either
+
+# don't ask me why this works
+statement ok
+ATTACH 'host=localhost user=root port=0 database=mysql ssl_mode=required ssl_ca=/xxx/ ssl_capath=/xxx/ ssl_cert=/xxx/ ssl_cipher=/xxx/ ssl_crl=/xxx/ ssl_crlpath=/xxx/ ssl_key=/xxx/' AS simple (TYPE MYSQL_SCANNER)


### PR DESCRIPTION
Implements #71 

This PR adds the [MySQL SSL connection parameters](https://dev.mysql.com/doc/refman/8.4/en/using-encrypted-connections.html)

* `ssl_mode`: The security state to use for the connection to the server: `disabled, required, verify_ca, verify_identity or preferred` (default: `preferred`)
* `ssl_ca`: The path name of the Certificate Authority (CA) certificate file. 
* `ssl_capath`: The path name of the directory that contains trusted SSL CA certificate files.
* `ssl_cert`: The path name of the client public key certificate file.
* `ssl_cipher`: The list of permissible ciphers for SSL encryption.
* `ssl_crl`: The path name of the file containing certificate revocation lists.
* `ssl_crlpath`: The path name of the directory that contains files containing certificate revocation lists.
* `ssl_key`: The path name of the client private key file.