### PR TITLE
Fix #65: use length instead of max_length when computing decimal width - as when using mysql_query max_length corresponds to the max length in the result set, as opposed to the max length of the field type

### DIFF
--- a/src/mysql_utils.cpp
+++ b/src/mysql_utils.cpp
@@ -332,7 +332,7 @@ LogicalType MySQLUtils::FieldToLogicalType(ClientContext &context, MYSQL_FIELD *
 		break;
 	case MYSQL_TYPE_DECIMAL:
 	case MYSQL_TYPE_NEWDECIMAL:
-		type_data.precision = int64_t(field->max_length) - 2; // -2 for minus sign and dot
+		type_data.precision = int64_t(field->length) - 2; // -2 for minus sign and dot
 		type_data.scale = field->decimals;
 		type_data.type_name = "decimal";
 		break;

--- a/test/sql/mysql_query.test
+++ b/test/sql/mysql_query.test
@@ -165,3 +165,11 @@ SELECT * FROM mysql_query('simple', 'SELECT * FROM datetime_tbl')
 1000-01-01	1000-01-01 00:00:00	1970-01-01 06:00:01+00	-838:59:59	2155
 9999-12-31	9999-12-31 23:59:59	2038-01-19 04:14:07+00	838:59:59	2000
 NULL	NULL	NULL	NULL	NULL
+
+# issue #65 - Decimal data type conversion issue with mysql_query function
+query II
+SELECT * FROM mysql_query('simple', 'SELECT * FROM tbl_issue65')
+----
+1	1.11
+2	2.22
+3	3.33

--- a/test/test_data.sql
+++ b/test/test_data.sql
@@ -149,3 +149,6 @@ VALUES (
 	ST_GeomFromText('MULTIPOLYGON(((0 5, 2 5, 2 7, 0 7, 0 5)))'),
 	ST_GeomFromText('GEOMETRYCOLLECTION EMPTY')
 );
+
+CREATE TABLE tbl_issue65 (col1 int, col2 decimal(5,2));
+insert into tbl_issue65 values (1,1.11), (2,2.22), (3,3.33);


### PR DESCRIPTION
Fixes #65 