### PR TITLE
use mutex to protect mysql_real_query

### DIFF
--- a/src/include/mysql_connection.hpp
+++ b/src/include/mysql_connection.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "duckdb/common/shared_ptr.hpp"
+#include "duckdb/common/mutex.hpp"
 #include "mysql_utils.hpp"
 #include "mysql_result.hpp"
 
@@ -77,6 +78,7 @@ public:
 private:
 	MYSQL_RES *MySQLExecute(const string &query);
 
+	mutex query_lock;
 	shared_ptr<OwnedMySQLConnection> connection;
 	string dsn;
 };

--- a/src/mysql_connection.cpp
+++ b/src/mysql_connection.cpp
@@ -39,6 +39,7 @@ MYSQL_RES *MySQLConnection::MySQLExecute(const string &query) {
 		Printer::Print(query + "\n");
 	}
 	auto con = GetConn();
+	lock_guard<mutex> l(query_lock);
 	int res = mysql_real_query(con, query.c_str(), query.size());
 	if (res != 0) {
 		throw IOException("Failed to run query \"%s\": %s\n", query.c_str(), mysql_error(con));


### PR DESCRIPTION
This fixes https://github.com/duckdb/duckdb_mysql/issues/97. I suspect it may also fix https://github.com/duckdb/duckdb_mysql/issues/90